### PR TITLE
Update how release health is determined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.0
+
+- Fixed an issue where the action would get stuck at 'Getting current replicas' for apps requesting more than one replica
+
 ## v0.3.0
 
 - Only add private key and wait for deploy if we are migrating [(#9)](https://github.com/mhanberg/gigalixir-action/pull/9)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.4.0
 
 - Fixed an issue where the action would get stuck at 'Getting current replicas' for apps requesting more than one replica
+- Does a health check every 10 seconds instead of increasing the wait time exponentially. Times out now after 10 minutes.
 
 ## v0.3.0
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -975,20 +975,20 @@ async function isNextReleaseHealthy(release, app) {
     await exec.exec(`gigalixir ps -a ${app}`, [], options);
   });
 
-  const pods = JSON.parse(releasesOutput).pods;
-  const pod = pods[0];
-
-  return pods.length === 1 && parseInt(pod.version) === release && pod.status === "Healthy";
+  const releases = JSON.parse(releasesOutput);
+  const pods = releases.pods;
+  return releases.pods.filter((pod) => (Number(pod.version) === release && pod.status === "Healthy")).length >= releases.replicas_desired;
 }
 
-async function waitForNewRelease(oldRelease, app, multiplier) {
+async function waitForNewRelease(oldRelease, app, attempts) {
+  const maxAttempts = 60;
+
   if (await isNextReleaseHealthy(oldRelease + 1, app)) {
     return await Promise.resolve(true);
   } else {
-    if (multiplier <= 10) {
-      await wait(Math.pow(2, multiplier));
-
-      await waitForNewRelease(oldRelease, app, multiplier + 1);
+    if (attempts <= maxAttempts) {
+      await wait(10);
+      await waitForNewRelease(oldRelease, app, attempts + 1);
     } else {
       throw "Taking too long for new release to deploy";
     }
@@ -1010,7 +1010,7 @@ async function getCurrentRelease(app) {
     await exec.exec(`gigalixir releases -a ${app}`, [], options);
   });
 
-  const currentRelease = parseInt(JSON.parse(releasesOutput)[0].version);
+  const currentRelease = Number(JSON.parse(releasesOutput)[0].version);
 
   return currentRelease;
 }

--- a/index.js
+++ b/index.js
@@ -29,20 +29,20 @@ async function isNextReleaseHealthy(release, app) {
     await exec.exec(`gigalixir ps -a ${app}`, [], options);
   });
 
-  const pods = JSON.parse(releasesOutput).pods;
-  const pod = pods[0];
-
-  return pods.length === 1 && Number(pod.version) === release && pod.status === "Healthy";
+  const releases = JSON.parse(releasesOutput);
+  const pods = releases.pods;
+  return releases.pods.filter((pod) => (Number(pod.version) === release && pod.status === "Healthy")).length >= releases.replicas_desired;
 }
 
-async function waitForNewRelease(oldRelease, app, multiplier) {
+async function waitForNewRelease(oldRelease, app, attempts) {
+  const maxAttempts = 60;
+
   if (await isNextReleaseHealthy(oldRelease + 1, app)) {
     return await Promise.resolve(true);
   } else {
-    if (multiplier <= 10) {
-      await wait(Math.pow(2, multiplier));
-
-      await waitForNewRelease(oldRelease, app, multiplier + 1);
+    if (attempts <= maxAttempts) {
+      await wait(10);
+      await waitForNewRelease(oldRelease, app, attempts + 1);
     } else {
       throw "Taking too long for new release to deploy";
     }

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ async function isNextReleaseHealthy(release, app) {
   const pods = JSON.parse(releasesOutput).pods;
   const pod = pods[0];
 
-  return pods.length === 1 && parseInt(pod.version) === release && pod.status === "Healthy";
+  return pods.length === 1 && Number(pod.version) === release && pod.status === "Healthy";
 }
 
 async function waitForNewRelease(oldRelease, app, multiplier) {
@@ -64,7 +64,7 @@ async function getCurrentRelease(app) {
     await exec.exec(`gigalixir releases -a ${app}`, [], options);
   });
 
-  const currentRelease = parseInt(JSON.parse(releasesOutput)[0].version);
+  const currentRelease = Number(JSON.parse(releasesOutput)[0].version);
 
   return currentRelease;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gigalixir-action",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gigalixir-action",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gigalixir-action",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Action to deploy to gigalixir",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Previously `isNextReleaseHealthy` waited until there was exactly 1 healthy pod returned by `gigalixir ps`. This is often not the case for single-replica apps (and never the case for multi-replica apps) when the release has actually succeeded.

This primary update in this PR is to change `isNextReleaseHealthy` to look for the `n` healthy replicas, where `n` is the number of requested replicas in Gigalixir's scaling configuration.

The PR also moves away from exponential backoff in fetching current replica status (which I only included because @mhanberg mentioned in #12). It now checks every 10 seconds and times out after 10 minutes. If there's any want for it, we could make this configurable (so that apps that usually release quickly can fail quickly and save some GH Actions minutes).

If you want these updates separated, or otherwise changed, let me know!