### PR TITLE
make first release ever through CI possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## v0.4.1
-- Fixed an issue when deploying an app to gigalixir for the first time ever through the CI
+- Deployment works if the action is making the very first deployment.
 ## v0.4.0
 
 - Fixed an issue where the action would get stuck at 'Getting current replicas' for apps requesting more than one replica

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## v0.4.1
+- Fixed an issue when deploying an app to gigalixir for the first time ever through the CI
 ## v0.4.0
 
 - Fixed an issue where the action would get stuck at 'Getting current replicas' for apps requesting more than one replica

--- a/dist/index.js
+++ b/dist/index.js
@@ -934,10 +934,72 @@ class ExecState extends events.EventEmitter {
 
 /***/ }),
 
+/***/ 82:
+/***/ (function(__unusedmodule, exports) {
+
+"use strict";
+
+// We use any as a valid input type
+/* eslint-disable @typescript-eslint/no-explicit-any */
+Object.defineProperty(exports, "__esModule", { value: true });
+/**
+ * Sanitizes an input into a string so it can be passed into issueCommand safely
+ * @param input input to sanitize into a string
+ */
+function toCommandValue(input) {
+    if (input === null || input === undefined) {
+        return '';
+    }
+    else if (typeof input === 'string' || input instanceof String) {
+        return input;
+    }
+    return JSON.stringify(input);
+}
+exports.toCommandValue = toCommandValue;
+//# sourceMappingURL=utils.js.map
+
+/***/ }),
+
 /***/ 87:
 /***/ (function(module) {
 
 module.exports = require("os");
+
+/***/ }),
+
+/***/ 102:
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+// For internal use, subject to change.
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+// We use any as a valid input type
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const fs = __importStar(__webpack_require__(747));
+const os = __importStar(__webpack_require__(87));
+const utils_1 = __webpack_require__(82);
+function issueCommand(command, message) {
+    const filePath = process.env[`GITHUB_${command}`];
+    if (!filePath) {
+        throw new Error(`Unable to find environment variable for file command ${command}`);
+    }
+    if (!fs.existsSync(filePath)) {
+        throw new Error(`Missing file at path: ${filePath}`);
+    }
+    fs.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os.EOL}`, {
+        encoding: 'utf8'
+    });
+}
+exports.issueCommand = issueCommand;
+//# sourceMappingURL=file-command.js.map
 
 /***/ }),
 
@@ -950,7 +1012,7 @@ const path = __webpack_require__(622);
 
 function wait(seconds) {
   return new Promise(resolve => {
-    if (typeof(seconds) !== 'number') {
+    if (typeof (seconds) !== 'number') {
       throw new Error('seconds not a number');
     }
 
@@ -976,7 +1038,6 @@ async function isNextReleaseHealthy(release, app) {
   });
 
   const releases = JSON.parse(releasesOutput);
-  const pods = releases.pods;
   return releases.pods.filter((pod) => (Number(pod.version) === release && pod.status === "Healthy")).length >= releases.replicas_desired;
 }
 
@@ -1010,18 +1071,34 @@ async function getCurrentRelease(app) {
     await exec.exec(`gigalixir releases -a ${app}`, [], options);
   });
 
-  const currentRelease = Number(JSON.parse(releasesOutput)[0].version);
+  const releases = JSON.parse(releasesOutput);
+  // first release number in gigalixir is 1
+  const currentRelease = releases.length && Number(releases[0].version) || 0;
 
   return currentRelease;
 }
 
+function printRelease(releaseNumber) {
+  return releaseNumber || "[NO PREV RELEASE]"
+}
+
 async function run() {
   try {
-    const gigalixirUsername = core.getInput('GIGALIXIR_USERNAME', { required: true });
-    const gigalixirPassword = core.getInput('GIGALIXIR_PASSWORD', { required: true });
-    const sshPrivateKey = core.getInput('SSH_PRIVATE_KEY', { required: true });
-    const gigalixirApp = core.getInput('GIGALIXIR_APP', { required: true });
-    const migrations = core.getInput('MIGRATIONS', { required: true });
+    const gigalixirUsername = core.getInput('GIGALIXIR_USERNAME', {
+      required: true
+    });
+    const gigalixirPassword = core.getInput('GIGALIXIR_PASSWORD', {
+      required: true
+    });
+    const sshPrivateKey = core.getInput('SSH_PRIVATE_KEY', {
+      required: true
+    });
+    const gigalixirApp = core.getInput('GIGALIXIR_APP', {
+      required: true
+    });
+    const migrations = core.getInput('MIGRATIONS', {
+      required: true
+    });
 
     await core.group("Installing gigalixir", async () => {
       await exec.exec('sudo pip install gigalixir --ignore-installed six')
@@ -1038,7 +1115,7 @@ async function run() {
     const currentRelease = await core.group("Getting current release", async () => {
       return await getCurrentRelease(gigalixirApp);
     });
-    core.info(`The current release is ${currentRelease}`);
+    core.info(`The current release is ${printRelease(currentRelease)}`);
 
     await core.group("Deploying to gigalixir", async () => {
       await exec.exec("git push -f gigalixir HEAD:refs/heads/master");
@@ -1058,7 +1135,7 @@ async function run() {
           await exec.exec(`gigalixir ps:migrate -a ${gigalixirApp}`)
         });
       } catch (error) {
-        core.warning(`Migration failed, rolling back to the previous release: ${currentRelease}`);
+        core.warning(`Migration failed, rolling back to the previous release: ${printRelease(currentRelease)}`);
         await core.group("Rolling back", async () => {
           await exec.exec(`gigalixir releases:rollback -a ${gigalixirApp}`)
         });
@@ -1066,14 +1143,12 @@ async function run() {
         core.setFailed(error.message);
       }
     }
-  }
-  catch (error) {
+  } catch (error) {
     core.setFailed(error.message);
   }
 }
 
 run();
-
 
 /***/ }),
 
@@ -1096,17 +1171,25 @@ module.exports = require("assert");
 
 "use strict";
 
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+};
 Object.defineProperty(exports, "__esModule", { value: true });
-const os = __webpack_require__(87);
+const os = __importStar(__webpack_require__(87));
+const utils_1 = __webpack_require__(82);
 /**
  * Commands
  *
  * Command Format:
- *   ##[name key=value;key=value]message
+ *   ::name key=value,key=value::message
  *
  * Examples:
- *   ##[warning]This is the user warning message
- *   ##[set-secret name=mypassword]definitelyNotAPassword!
+ *   ::warning::This is the message
+ *   ::set-env name=MY_VAR::some value
  */
 function issueCommand(command, properties, message) {
     const cmd = new Command(command, properties, message);
@@ -1131,34 +1214,39 @@ class Command {
         let cmdStr = CMD_STRING + this.command;
         if (this.properties && Object.keys(this.properties).length > 0) {
             cmdStr += ' ';
+            let first = true;
             for (const key in this.properties) {
                 if (this.properties.hasOwnProperty(key)) {
                     const val = this.properties[key];
                     if (val) {
-                        // safely append the val - avoid blowing up when attempting to
-                        // call .replace() if message is not a string for some reason
-                        cmdStr += `${key}=${escape(`${val || ''}`)},`;
+                        if (first) {
+                            first = false;
+                        }
+                        else {
+                            cmdStr += ',';
+                        }
+                        cmdStr += `${key}=${escapeProperty(val)}`;
                     }
                 }
             }
         }
-        cmdStr += CMD_STRING;
-        // safely append the message - avoid blowing up when attempting to
-        // call .replace() if message is not a string for some reason
-        const message = `${this.message || ''}`;
-        cmdStr += escapeData(message);
+        cmdStr += `${CMD_STRING}${escapeData(this.message)}`;
         return cmdStr;
     }
 }
 function escapeData(s) {
-    return s.replace(/\r/g, '%0D').replace(/\n/g, '%0A');
+    return utils_1.toCommandValue(s)
+        .replace(/%/g, '%25')
+        .replace(/\r/g, '%0D')
+        .replace(/\n/g, '%0A');
 }
-function escape(s) {
-    return s
+function escapeProperty(s) {
+    return utils_1.toCommandValue(s)
+        .replace(/%/g, '%25')
         .replace(/\r/g, '%0D')
         .replace(/\n/g, '%0A')
-        .replace(/]/g, '%5D')
-        .replace(/;/g, '%3B');
+        .replace(/:/g, '%3A')
+        .replace(/,/g, '%2C');
 }
 //# sourceMappingURL=command.js.map
 
@@ -1178,10 +1266,19 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 const command_1 = __webpack_require__(431);
-const os = __webpack_require__(87);
-const path = __webpack_require__(622);
+const file_command_1 = __webpack_require__(102);
+const utils_1 = __webpack_require__(82);
+const os = __importStar(__webpack_require__(87));
+const path = __importStar(__webpack_require__(622));
 /**
  * The code to exit an action
  */
@@ -1200,34 +1297,45 @@ var ExitCode;
 // Variables
 //-----------------------------------------------------------------------
 /**
- * sets env variable for this action and future actions in the job
+ * Sets env variable for this action and future actions in the job
  * @param name the name of the variable to set
- * @param val the value of the variable
+ * @param val the value of the variable. Non-string values will be converted to a string via JSON.stringify
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function exportVariable(name, val) {
-    process.env[name] = val;
-    command_1.issueCommand('set-env', { name }, val);
+    const convertedVal = utils_1.toCommandValue(val);
+    process.env[name] = convertedVal;
+    const filePath = process.env['GITHUB_ENV'] || '';
+    if (filePath) {
+        const delimiter = '_GitHubActionsFileCommandDelimeter_';
+        const commandValue = `${name}<<${delimiter}${os.EOL}${convertedVal}${os.EOL}${delimiter}`;
+        file_command_1.issueCommand('ENV', commandValue);
+    }
+    else {
+        command_1.issueCommand('set-env', { name }, convertedVal);
+    }
 }
 exports.exportVariable = exportVariable;
 /**
- * exports the variable and registers a secret which will get masked from logs
- * @param name the name of the variable to set
- * @param val value of the secret
+ * Registers a secret which will get masked from logs
+ * @param secret value of the secret
  */
-function exportSecret(name, val) {
-    exportVariable(name, val);
-    // the runner will error with not implemented
-    // leaving the function but raising the error earlier
-    command_1.issueCommand('set-secret', {}, val);
-    throw new Error('Not implemented.');
+function setSecret(secret) {
+    command_1.issueCommand('add-mask', {}, secret);
 }
-exports.exportSecret = exportSecret;
+exports.setSecret = setSecret;
 /**
  * Prepends inputPath to the PATH (for this action and future actions)
  * @param inputPath
  */
 function addPath(inputPath) {
-    command_1.issueCommand('add-path', {}, inputPath);
+    const filePath = process.env['GITHUB_PATH'] || '';
+    if (filePath) {
+        file_command_1.issueCommand('PATH', inputPath);
+    }
+    else {
+        command_1.issueCommand('add-path', {}, inputPath);
+    }
     process.env['PATH'] = `${inputPath}${path.delimiter}${process.env['PATH']}`;
 }
 exports.addPath = addPath;
@@ -1250,12 +1358,22 @@ exports.getInput = getInput;
  * Sets the value of an output.
  *
  * @param     name     name of the output to set
- * @param     value    value to store
+ * @param     value    value to store. Non-string values will be converted to a string via JSON.stringify
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function setOutput(name, value) {
     command_1.issueCommand('set-output', { name }, value);
 }
 exports.setOutput = setOutput;
+/**
+ * Enables or disables the echoing of commands into stdout for the rest of the step.
+ * Echoing is disabled by default if ACTIONS_STEP_DEBUG is not set.
+ *
+ */
+function setCommandEcho(enabled) {
+    command_1.issue('echo', enabled ? 'on' : 'off');
+}
+exports.setCommandEcho = setCommandEcho;
 //-----------------------------------------------------------------------
 // Results
 //-----------------------------------------------------------------------
@@ -1273,6 +1391,13 @@ exports.setFailed = setFailed;
 // Logging Commands
 //-----------------------------------------------------------------------
 /**
+ * Gets whether Actions Step Debug is on or not
+ */
+function isDebug() {
+    return process.env['RUNNER_DEBUG'] === '1';
+}
+exports.isDebug = isDebug;
+/**
  * Writes debug message to user log
  * @param message debug message
  */
@@ -1282,18 +1407,18 @@ function debug(message) {
 exports.debug = debug;
 /**
  * Adds an error issue
- * @param message error issue message
+ * @param message error issue message. Errors will be converted to string via toString()
  */
 function error(message) {
-    command_1.issue('error', message);
+    command_1.issue('error', message instanceof Error ? message.toString() : message);
 }
 exports.error = error;
 /**
  * Adds an warning issue
- * @param message warning issue message
+ * @param message warning issue message. Errors will be converted to string via toString()
  */
 function warning(message) {
-    command_1.issue('warning', message);
+    command_1.issue('warning', message instanceof Error ? message.toString() : message);
 }
 exports.warning = warning;
 /**
@@ -1344,6 +1469,30 @@ function group(name, fn) {
     });
 }
 exports.group = group;
+//-----------------------------------------------------------------------
+// Wrapper action state
+//-----------------------------------------------------------------------
+/**
+ * Saves state for current action, the state can only be retrieved by this action's post job execution.
+ *
+ * @param     name     name of the state to store
+ * @param     value    value to store. Non-string values will be converted to a string via JSON.stringify
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function saveState(name, value) {
+    command_1.issueCommand('save-state', { name }, value);
+}
+exports.saveState = saveState;
+/**
+ * Gets the value of an state set by this action's main execution.
+ *
+ * @param     name     name of the state to get
+ * @returns   string
+ */
+function getState(name) {
+    return process.env[`STATE_${name}`] || '';
+}
+exports.getState = getState;
 //# sourceMappingURL=core.js.map
 
 /***/ }),

--- a/dist/index.js
+++ b/dist/index.js
@@ -1012,7 +1012,7 @@ const path = __webpack_require__(622);
 
 function wait(seconds) {
   return new Promise(resolve => {
-    if (typeof (seconds) !== 'number') {
+    if ((typeof seconds) !== 'number') {
       throw new Error('seconds not a number');
     }
 
@@ -1072,33 +1072,27 @@ async function getCurrentRelease(app) {
   });
 
   const releases = JSON.parse(releasesOutput);
-  // first release number in gigalixir is 1
-  const currentRelease = releases.length && Number(releases[0].version) || 0;
+  const currentRelease = releases.length ? Number(releases[0].version) : 0;
 
   return currentRelease;
 }
 
-function printRelease(releaseNumber) {
-  return releaseNumber || "[NO PREV RELEASE]"
+function formatReleaseMessage(releaseNumber) {
+  return releaseNumber ?
+    `The current release is ${releaseNumber}` :
+    "This is the first release";
 }
 
 async function run() {
   try {
-    const gigalixirUsername = core.getInput('GIGALIXIR_USERNAME', {
+    const baseInputOptions = {
       required: true
-    });
-    const gigalixirPassword = core.getInput('GIGALIXIR_PASSWORD', {
-      required: true
-    });
-    const sshPrivateKey = core.getInput('SSH_PRIVATE_KEY', {
-      required: true
-    });
-    const gigalixirApp = core.getInput('GIGALIXIR_APP', {
-      required: true
-    });
-    const migrations = core.getInput('MIGRATIONS', {
-      required: true
-    });
+    };
+    const gigalixirUsername = core.getInput('GIGALIXIR_USERNAME', baseInputOptions);
+    const gigalixirPassword = core.getInput('GIGALIXIR_PASSWORD', baseInputOptions);
+    const sshPrivateKey = core.getInput('SSH_PRIVATE_KEY', baseInputOptions);
+    const gigalixirApp = core.getInput('GIGALIXIR_APP', baseInputOptions);
+    const migrations = core.getInput('MIGRATIONS', baseInputOptions);
 
     await core.group("Installing gigalixir", async () => {
       await exec.exec('sudo pip install gigalixir --ignore-installed six')
@@ -1115,7 +1109,8 @@ async function run() {
     const currentRelease = await core.group("Getting current release", async () => {
       return await getCurrentRelease(gigalixirApp);
     });
-    core.info(`The current release is ${printRelease(currentRelease)}`);
+
+    core.info(formatReleaseMessage(currentRelease));
 
     await core.group("Deploying to gigalixir", async () => {
       await exec.exec("git push -f gigalixir HEAD:refs/heads/master");
@@ -1135,10 +1130,14 @@ async function run() {
           await exec.exec(`gigalixir ps:migrate -a ${gigalixirApp}`)
         });
       } catch (error) {
-        core.warning(`Migration failed, rolling back to the previous release: ${printRelease(currentRelease)}`);
-        await core.group("Rolling back", async () => {
-          await exec.exec(`gigalixir releases:rollback -a ${gigalixirApp}`)
-        });
+        if (currentRelease === 0) {
+          core.warning("Migration failed");
+        } else {
+          core.warning(`Migration failed, rolling back to the previous release: ${currentRelease}`);
+          await core.group("Rolling back", async () => {
+            await exec.exec(`gigalixir releases:rollback -a ${gigalixirApp}`)
+          });
+        }
 
         core.setFailed(error.message);
       }

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const path = require('path');
 
 function wait(seconds) {
   return new Promise(resolve => {
-    if (typeof(seconds) !== 'number') {
+    if (typeof (seconds) !== 'number') {
       throw new Error('seconds not a number');
     }
 
@@ -30,7 +30,6 @@ async function isNextReleaseHealthy(release, app) {
   });
 
   const releases = JSON.parse(releasesOutput);
-  const pods = releases.pods;
   return releases.pods.filter((pod) => (Number(pod.version) === release && pod.status === "Healthy")).length >= releases.replicas_desired;
 }
 
@@ -64,18 +63,34 @@ async function getCurrentRelease(app) {
     await exec.exec(`gigalixir releases -a ${app}`, [], options);
   });
 
-  const currentRelease = Number(JSON.parse(releasesOutput)[0].version);
+  const releases = JSON.parse(releasesOutput);
+  // first release number in gigalixir is 1
+  const currentRelease = releases.length && Number(releases[0].version) || 0;
 
   return currentRelease;
 }
 
+function printRelease(releaseNumber) {
+  return releaseNumber || "[NO PREV RELEASE]"
+}
+
 async function run() {
   try {
-    const gigalixirUsername = core.getInput('GIGALIXIR_USERNAME', { required: true });
-    const gigalixirPassword = core.getInput('GIGALIXIR_PASSWORD', { required: true });
-    const sshPrivateKey = core.getInput('SSH_PRIVATE_KEY', { required: true });
-    const gigalixirApp = core.getInput('GIGALIXIR_APP', { required: true });
-    const migrations = core.getInput('MIGRATIONS', { required: true });
+    const gigalixirUsername = core.getInput('GIGALIXIR_USERNAME', {
+      required: true
+    });
+    const gigalixirPassword = core.getInput('GIGALIXIR_PASSWORD', {
+      required: true
+    });
+    const sshPrivateKey = core.getInput('SSH_PRIVATE_KEY', {
+      required: true
+    });
+    const gigalixirApp = core.getInput('GIGALIXIR_APP', {
+      required: true
+    });
+    const migrations = core.getInput('MIGRATIONS', {
+      required: true
+    });
 
     await core.group("Installing gigalixir", async () => {
       await exec.exec('sudo pip install gigalixir --ignore-installed six')
@@ -92,7 +107,7 @@ async function run() {
     const currentRelease = await core.group("Getting current release", async () => {
       return await getCurrentRelease(gigalixirApp);
     });
-    core.info(`The current release is ${currentRelease}`);
+    core.info(`The current release is ${printRelease(currentRelease)}`);
 
     await core.group("Deploying to gigalixir", async () => {
       await exec.exec("git push -f gigalixir HEAD:refs/heads/master");
@@ -112,7 +127,7 @@ async function run() {
           await exec.exec(`gigalixir ps:migrate -a ${gigalixirApp}`)
         });
       } catch (error) {
-        core.warning(`Migration failed, rolling back to the previous release: ${currentRelease}`);
+        core.warning(`Migration failed, rolling back to the previous release: ${printRelease(currentRelease)}`);
         await core.group("Rolling back", async () => {
           await exec.exec(`gigalixir releases:rollback -a ${gigalixirApp}`)
         });
@@ -120,8 +135,7 @@ async function run() {
         core.setFailed(error.message);
       }
     }
-  }
-  catch (error) {
+  } catch (error) {
     core.setFailed(error.message);
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gigalixir-action",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gigalixir-action",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Action to deploy to gigalixir",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I attempted to make my first release to gigalixir through the CI (not the CLI first and then the CI) and I got the following error

<img width="617" alt="Screenshot 2021-01-20 at 21 59 40" src="https://user-images.githubusercontent.com/622973/105228238-02b55a80-5b6b-11eb-8c69-94835773dc63.png">

```bash
Getting current release
  /usr/local/bin/gigalixir releases -a XXXXXXX
  []
  
Error: Cannot read property 'version' of undefined
```
I verified the error by running `gigalixir releases -a XXXX` which returned an empty array as I hadn't done any release previously using the CLI

After making the first release using the CLI I re-run the command and got back
```
$ gigalixir releases -a XXXXXX

[
  {
    "created_at": "2021-01-20T19:40:31.000+00:00",
    "sha": "587fe8dcc70f3557b9912809f3ea745d071b2b43",
    "summary": "Deployed. Set `DATABASE_URL` config var. Set `POOL_SIZE` config var.",
    "version": 1
  }
]
```
So my approach was to set the `currentRelease` number to `0` if no previous release was found because of the checks made (`oldRelease + 1`) to detect readiness, but print an explicit `[NO PREV RELEASE]` 'version' if no previous release was found

Note: also made an unrelated change to remove the `const pods=...` assignment and make the linter happy.