### PR TITLE
use pip3 to install gigalixir CLI

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,7 +87,7 @@ async function run() {
     const migrations = core.getInput('MIGRATIONS', baseInputOptions);
 
     await core.group("Installing gigalixir", async () => {
-      await exec.exec('sudo pip install gigalixir --ignore-installed six')
+      await exec.exec('sudo pip3 install gigalixir --ignore-installed six')
     });
 
     await core.group("Logging in to gigalixir", async () => {


### PR DESCRIPTION
Python 2 [reached EOL](https://gigalixir.readthedocs.io/en/latest/getting-started-guide.html#prerequisites) at January 1st 2020, should hopefully fix #21 but I don't know Github Actions well enough to test it :D