### PR TITLE
README: Fix a missed master -> main

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ deploy:
   steps:
     - uses: actions/checkout@v2
       with:
-        ref: master # Checkout out master instead of the latest commit
+        ref: main # Check out main instead of the latest commit
         fetch-depth: 0 # Checkout the whole branch
         
     - uses: actions/setup-python@v2


### PR DESCRIPTION
The "if" condition already uses "main" so I assume we want the docs to consistently use "main".