### PR TITLE
Add Subfolder Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ deploy:
         GIGALIXIR_APP: my-gigalixir-app # Feel free to also put this in your secrets
         SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
         MIGRATIONS: false  # defaults to true
+        APP_SUBFOLDER: my-app-subfolder  # Add only if you want to deploy an app that is not at the root of your repository
 ```
 
 ## Migrations

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,9 @@ inputs:
     description: 'Configuration for migrations'
     required: true
     default: true
+  APP_SUBFOLDER:
+    description: 'Subfolder of your app'
+    required: false
 
 runs:
   using: 'node12'

--- a/dist/index.js
+++ b/dist/index.js
@@ -1093,6 +1093,7 @@ async function run() {
     const sshPrivateKey = core.getInput('SSH_PRIVATE_KEY', baseInputOptions);
     const gigalixirApp = core.getInput('GIGALIXIR_APP', baseInputOptions);
     const migrations = core.getInput('MIGRATIONS', baseInputOptions);
+    const appSubfolder = core.getInput('APP_SUBFOLDER', { required: false });
 
     await core.group("Installing gigalixir", async () => {
       await exec.exec('pip3 install gigalixir')
@@ -1113,7 +1114,11 @@ async function run() {
     core.info(formatReleaseMessage(currentRelease));
 
     await core.group("Deploying to gigalixir", async () => {
-      await exec.exec("git push -f gigalixir HEAD:refs/heads/master");
+      if (appSubfolder) {
+        await exec.exec(`git subtree push --prefix ${appSubfolder} gigalixir master`);
+      } else {
+        await exec.exec("git push -f gigalixir HEAD:refs/heads/master");
+      }
     });
 
     if (migrations === "true") {

--- a/index.js
+++ b/index.js
@@ -85,6 +85,7 @@ async function run() {
     const sshPrivateKey = core.getInput('SSH_PRIVATE_KEY', baseInputOptions);
     const gigalixirApp = core.getInput('GIGALIXIR_APP', baseInputOptions);
     const migrations = core.getInput('MIGRATIONS', baseInputOptions);
+    const appSubfolder = core.getInput('APP_SUBFOLDER', { required: false });
 
     await core.group("Installing gigalixir", async () => {
       await exec.exec('pip3 install gigalixir')
@@ -105,7 +106,11 @@ async function run() {
     core.info(formatReleaseMessage(currentRelease));
 
     await core.group("Deploying to gigalixir", async () => {
-      await exec.exec("git push -f gigalixir HEAD:refs/heads/master");
+      if (appSubfolder) {
+        await exec.exec(`git subtree push --prefix ${appSubfolder} gigalixir master`);
+      } else {
+        await exec.exec("git push -f gigalixir HEAD:refs/heads/master");
+      }
     });
 
     if (migrations === "true") {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gigalixir-action",
-  "version": "0.4.1",
+  "version": "0.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
### Description
This PR pretends to solve the issue of having to deploy an app to Gigalixir that isn't at the root of the repository. I have added a non required input named `APP_SUBFOLDER` that will hold the name of the subfolder of the Phoenix application that will be pushed to the Gigalixir remote. This can be very convenient when having monorepos.

**Additional Information**
For more information regarding the deployment of apps that are not on the root of the repository, please check the following documentation from Gigalixir:

https://gigalixir.readthedocs.io/en/latest/deploy.html#can-i-deploy-an-app-that-isn-t-at-the-root-of-my-repository