### PR TITLE
Don't always set GIGALIXIR_CLEAN header

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1084,7 +1084,7 @@ function formatReleaseMessage(releaseNumber) {
 }
 
 function addExtraFlagCleanCache(gigalixirClean) {
-  return gigalixirClean ? ` -c http.extraheader="GIGALIXIR-CLEAN: true" ` : ""
+  return (gigalixirClean === "true") ? ` -c http.extraheader="GIGALIXIR-CLEAN: true" ` : ""
 }
 
 async function run() {

--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ function formatReleaseMessage(releaseNumber) {
 }
 
 function addExtraFlagCleanCache(gigalixirClean) {
-  return gigalixirClean ? ` -c http.extraheader="GIGALIXIR-CLEAN: true" ` : ""
+  return (gigalixirClean === "true") ? ` -c http.extraheader="GIGALIXIR-CLEAN: true" ` : ""
 }
 
 async function run() {


### PR DESCRIPTION
The boolean values from the inputs comes in as strings, so the default value of `"false"` still evaluates as truthy and the header is always sent.